### PR TITLE
chore(deps): enable automatic updates for GitHub Actions via Dependabot

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install asdf
-      uses: asdf-vm/actions/setup@7dd2d2ea8a8f52028ca0fdfba65767b8f2db8298 # v2
+      uses: asdf-vm/actions/setup@7dd2d2ea8a8f52028ca0fdfba65767b8f2db8298 # 7dd2d2e
 
     - name: Install asdf tools
       shell: bash

--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -4,7 +4,7 @@ runs:
   using: composite
   steps:
     - name: Install asdf
-      uses: asdf-vm/actions/setup@7dd2d2ea8a8f52028ca0fdfba65767b8f2db8298 # 7dd2d2e
+      uses: asdf-vm/actions/setup@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
 
     - name: Install asdf tools
       shell: bash

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+   - package-ecosystem: github-actions
+     directory: /
+     schedule:
+        interval: monthly
+     groups:
+        actions:
+           patterns:
+              - '*'

--- a/.github/workflows/lint-ansible.yaml
+++ b/.github/workflows/lint-ansible.yaml
@@ -19,7 +19,7 @@ jobs:
   ansible-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: ./.github/actions/setup
       - name: Install ansible role/collection dependencies
         working-directory: ./ansible

--- a/.github/workflows/lint-helm.yaml
+++ b/.github/workflows/lint-helm.yaml
@@ -20,7 +20,7 @@ jobs:
   helm-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: ./.github/actions/setup
       - name: Check if kubernetes/*/* is not empty
         id: check-kubernetes-directory

--- a/.github/workflows/lint-terraform.yaml
+++ b/.github/workflows/lint-terraform.yaml
@@ -19,7 +19,7 @@ jobs:
   terraform-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - uses: ./.github/actions/setup
       - name: Lint
         working-directory: ./terraform


### PR DESCRIPTION

### 💚 Dependabot automatic updates
This PR enables automatic updates for GitHub Actions via [Dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot).

Dependabot will periodically check for new versions of the actions and create a PR to update the version used in the repository.

This should help keeping your GitHub Actions up to date with the latest versions of the actions.

#### 🔍 How was this detected and generated?
This PR was generated using [ethpandaops/github-actions-checker](https://github.com/ethpandaops/github-actions-checker).
